### PR TITLE
Keep hash consistent with what was specified in enum_accessor definition

### DIFF
--- a/lib/enum_accessor.rb
+++ b/lib/enum_accessor.rb
@@ -21,7 +21,7 @@ module EnumAccessor
       definition = options[:class_attribute] || column.to_s.pluralize.to_sym
       class_attribute definition
       class_attribute "_human_#{definition}"
-      send "#{definition}=", dict.with_indifferent_access.freeze
+      send "#{definition}=", dict.freeze
       send "_human_#{definition}=", {}
 
       # Getter


### PR DESCRIPTION
Hi there,

Thank you for maintaining this great little gem. I've been using it for a while now, despite Rails 4.1's native enum support :)

Recently, I was tripped up by a little inconsistency:

```ruby
class User < ActiveRecord::Base
  enum_accessor :gender, [:female, :male]
end

user = User.new
user.gender = :female
user.gender             # => "female"
```

Notice how I assign `:female` as a symbol to `user.gender` but when I access the field again, I get back a *string* `"female"`. This tripped me because my expectation was that I'd get back the same value/datatype that I had assigned to the field, when I access the field.

Looks like `.with_indifferent_access` is the one causing this issue. I've attached a PR that fixes it. Please let me know if this works.

